### PR TITLE
Use default rust profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN chmod 755 /rustup/rustup.sh
 
 ENV USER=xmtp
 USER xmtp
-RUN /rustup/rustup.sh -y --default-toolchain stable --profile minimal
+RUN /rustup/rustup.sh -y --default-toolchain stable
 
 ENV PATH=$PATH:~xmtp/.cargo/bin
 


### PR DESCRIPTION
## Summary

I've been digging into [issues with building the `libxmtp` docker image](https://github.com/xmtp/libxmtp/actions/runs/6899211744/job/18770438200). 

They all fail with errors that look like this. 
<img width="854" alt="CleanShot 2023-11-17 at 14 20 41@2x" src="https://github.com/xmtp/rust/assets/65710/3ee399eb-7db8-4f51-ac40-d9ad3a7cdfe2">

Using the default profile in the base rust image resolves the issue. It's a bit strange, given that the only difference between the default profile and the one we are using (including the components manually added) [appears to be `rust-docs`](https://rust-lang.github.io/rustup/concepts/profiles.html).
 
I'd like to better understand what the root cause is, but I think we should merge this to unblock `libxmtp` CI until we have a better solution. I can see the case for including the minimal profile in the base image if this is to be used for production builds as well as CI.

## Notes
I tested this by building the image locally and using my local image in `libxmtp`. Everything worked after I did that. But if this is a more exotic issue than I think, maybe this won't actually fix it when built in CI.